### PR TITLE
Fix reset scroll

### DIFF
--- a/src/app/components/Swap/Currency/SelectCurrency.tsx
+++ b/src/app/components/Swap/Currency/SelectCurrency.tsx
@@ -13,11 +13,7 @@ type Props = {
 }
 
 export const SelectCurrency: FC<Props> = ({ type, current }) => {
-  const [Modal, open, close] = useModal('root', {
-    focusTrapOptions: {
-      preventScroll: false,
-    },
-  })
+  const [Modal, open, close] = useModal('root')
   const { currencies, setCurrencyFrom, setCurrencyTo } = useContext(SwapContext)
   const currency = useMemo(() => (type === 'from' ? currencies.from : currencies.to), [currencies, type])
 


### PR DESCRIPTION
When correcting scrolling, there is a new bug that causes scrolling to be reset when the path is updated. This is the fix for that.