### PR TITLE
Fix isFullPath to remain undefined if full_reply is not true and is empty alternatives.

### DIFF
--- a/src/hooks/usePathFind.ts
+++ b/src/hooks/usePathFind.ts
@@ -75,7 +75,6 @@ export const usePathFind = ({ account: _account, from: _from, to: _to }: Props) 
     if (!enable) return
     pathFindClose(client).then(() => {
       setAlternatives([])
-      setIsFullPath(undefined)
       if (['', '0'].includes(parseAmountValue(parseToXrpAmount(from)))) {
         setActive(false)
         return
@@ -93,11 +92,17 @@ export const usePathFind = ({ account: _account, from: _from, to: _to }: Props) 
 
   useEffect(() => {
     if (!enable) return
-    const onSwapPathFind = (stream: any) => {
-      if (!stream.alternatives && !stream.result?.alternatives) {
+    const onSwapPathFind = (_stream: any) => {
+      const stream = _stream.result ? _stream.result : _stream
+      if (stream?.closed) {
+        setIsFullPath(undefined)
         return
       }
-      const alternatives = (stream.alternatives || stream.result.alternatives) as PathOption[]
+      if (!stream.alternatives || (stream.full_reply !== true && stream.alternatives.length === 0)) {
+        // Skip if (not a path stream) or (not full_reply and alternatives is empty)
+        return
+      }
+      const alternatives = stream.alternatives as PathOption[]
       setAlternatives(alternatives || [])
       if (stream.full_reply !== true) {
         setIsFullPath(false)


### PR DESCRIPTION
Ignore empty alternatives if full_reply is not true

Fix isFullPath being false in case of IOU-IOU swap even though no path was found at all.

If isFullPath is true or false, the path should have been found. (If true, it is possible that the path was not found due to lack of liquidity.)